### PR TITLE
Add new ad metrics

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,7 +67,7 @@ numeric_internal_cols = [
     'visits',
     'attention', 'interest', 'deseo', # Nuevas de embudo
     'addcart', 'checkout', 'purchases', 
-    'value', 'value_avg', 'roas', 'cpa',
+    'value', 'value_avg', 'roas', 'cpa', 'ncpa', 'aov', 'cvr',
     'rv3', 'rv25', 'rv75', 'rv100', 'rtime' # Video
 ]
 

--- a/data_processing/aggregators.py
+++ b/data_processing/aggregators.py
@@ -77,6 +77,9 @@ def _agregar_datos_diarios(df_combined, status_queue, selected_adsets=None):
         df_daily['rv25_pct']=safe_division_pct(rv25_s,base_rv_val); df_daily['rv75_pct']=safe_division_pct(rv75_s,base_rv_val); df_daily['rv100_pct']=safe_division_pct(rv100_s,base_rv_val)
         df_daily['lpv_rate']=safe_division_pct(vi_visits,c_clicks); df_daily['purchase_rate']=safe_division_pct(p_purch,vi_visits)
         df_daily['ctr_out'] = safe_division_pct(co_clicks_out, i_impr)
+        df_daily['aov'] = safe_division(v_value, p_purch)
+        df_daily['cvr'] = df_daily['purchase_rate']
+        df_daily['ncpa'] = df_daily['cpa']
 
         log_and_update("Métricas derivadas diarias calculadas.")
         log_and_update("Agregación diaria finalizada."); return df_daily

--- a/data_processing/orchestrators.py
+++ b/data_processing/orchestrators.py
@@ -254,12 +254,16 @@ def procesar_reporte_bitacora(input_files, output_dir, output_filename, status_q
 
             log("\n--- Análisis de Bitácora ---")
             log("\n--- Iniciando Agregación Diaria (Bitácora) ---", importante=True)
-            df_daily_agg_full = _agregar_datos_diarios(df_combined, status_queue, selected_adsets) 
+            df_daily_agg_full = _agregar_datos_diarios(df_combined, status_queue, selected_adsets)
 
             if df_daily_agg_full is None or df_daily_agg_full.empty or 'date' not in df_daily_agg_full.columns or df_daily_agg_full['date'].dropna().empty:
                 log("!!! Falló agregación diaria o no hay fechas válidas. Abortando Bitácora. !!!", importante=True)
                 status_queue.put("---ERROR---"); return
             log("Agregación diaria OK.")
+
+            log("--- Calculando Días Activos Totales (Bitácora) ---", importante=True)
+            active_days_results = _calcular_dias_activos_totales(df_combined)
+            active_days_ad = active_days_results.get('Anuncio', pd.DataFrame())
 
             min_date_overall = df_daily_agg_full['date'].min().date()
             max_date_overall = df_daily_agg_full['date'].max().date()
@@ -475,7 +479,7 @@ def procesar_reporte_bitacora(input_files, output_dir, output_filename, status_q
 
             _generar_tabla_embudo_bitacora(df_daily_total_for_bitacora, bitacora_periods_list, log, detected_currency, period_type=bitacora_comparison_type)
 
-            _generar_tabla_bitacora_top_ads(df_daily_agg_full, bitacora_periods_list, log, detected_currency)
+            _generar_tabla_bitacora_top_ads(df_daily_agg_full, bitacora_periods_list, active_days_ad, log, detected_currency)
 
             log("\n\n============================================================");log(f"===== Resumen del Proceso (Bitácora {bitacora_comparison_type}) =====");log("============================================================")
             if log_summary_messages_orchestrator: [log(f"  - {re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip().replace('---','-')}") for msg in log_summary_messages_orchestrator if re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip()]

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -793,7 +793,7 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
          log_func("Adv: No se pudo ordenar por gasto (columna ausente).")
          df_ads_sorted_spend = filtered_ads.copy()
 
-    t1_headers=['Campaña','AdSet','Nombre ADs','dias','Estado','Alcance','ROAS','Compras','CPM','CTR','CTR Saliente','Var U7 CTR','Var U7 ROAS','Var U7 Freq','Var U7 CPM','Var U7 Compras']
+    t1_headers=['Campaña','AdSet','Nombre ADs','dias','Estado','Alcance','ROAS','Compras','CVR (%)','AOV','NCPA','CPM','CTR','CTR Saliente','Var U7 CTR','Var U7 ROAS','Var U7 Freq','Var U7 CPM','Var U7 Compras']
     t1_data=[]
     for _,r_row in df_ads_sorted_spend.iterrows(): t1_data.append({
         'Campaña':r_row.get('Campaign','-'),
@@ -804,6 +804,9 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
         'Alcance':fmt_int(r_row.get('reach_global')),
         'ROAS':f"{fmt_float(r_row.get('roas_global'),2)}x",
         'Compras':fmt_int(r_row.get('purchases_global')),
+        'CVR (%)':fmt_pct(safe_division_pct(r_row.get('purchases_global'), r_row.get('visits_global')),2),
+        'AOV':f"{detected_currency}{fmt_float(safe_division(r_row.get('value_global'), r_row.get('purchases_global')),2)}",
+        'NCPA':f"{detected_currency}{fmt_float(r_row.get('cpa_global'),2)}",
         'CPM':f"{detected_currency}{fmt_float(r_row.get('cpm_global'),2)}",
         'CTR':fmt_pct(r_row.get('ctr_global'),2),
         'CTR Saliente':fmt_pct(r_row.get('ctr_out_global'),2),
@@ -887,7 +890,7 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         if col in df_daily_agg_copy.columns:
             df_daily_agg_copy[col] = df_daily_agg_copy[col].astype(str)
 
-    agg_dict={'spend':'sum','value':'sum','purchases':'sum','clicks':'sum','impr':'sum','reach':'sum','rtime':'mean', 'rv3':'sum'}
+    agg_dict={'spend':'sum','value':'sum','purchases':'sum','clicks':'sum','visits':'sum','impr':'sum','reach':'sum','rtime':'mean', 'rv3':'sum'}
     agg_dict_available={k:v for k,v in agg_dict.items() if k in df_daily_agg_copy.columns} 
     if not agg_dict_available or 'spend' not in agg_dict_available or 'impr' not in agg_dict_available: 
         log_func("   No hay métricas suficientes (falta spend o impr) para agregar para Top Ads."); return
@@ -925,7 +928,7 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         log_func("   No se pudo ordenar Top Ads (faltan columnas spend/roas). Mostrando los primeros {top_n}.")
         df_top=df_top.head(top_n)
 
-    table_headers=['Campaña','AdSet','Anuncio','Días Act','Gasto','ROAS','Compras','CTR (%)','Frecuencia','Tiempo RV (s)']
+    table_headers=['Campaña','AdSet','Anuncio','Días Act','Gasto','ROAS','Compras','CVR (%)','AOV','NCPA','CTR (%)','Frecuencia','Tiempo RV (s)']
     table_data=[]
     for _,row_val in df_top.iterrows(): table_data.append({
         'Campaña':row_val.get('Campaign','-'),
@@ -935,6 +938,9 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         'Gasto':f"{detected_currency}{fmt_float(row_val.get('spend'),0)}",
         'ROAS':f"{fmt_float(row_val.get('roas'),2)}x",
         'Compras':fmt_int(row_val.get('purchases')),
+        'CVR (%)':fmt_pct(safe_division_pct(row_val.get('purchases'), row_val.get('visits')),2),
+        'AOV':f"{detected_currency}{fmt_float(safe_division(row_val.get('value'), row_val.get('purchases')),2)}",
+        'NCPA':f"{detected_currency}{fmt_float(safe_division(row_val.get('spend'), row_val.get('purchases')),2)}",
         'CTR (%)':fmt_pct(row_val.get('ctr'),2),
         'Frecuencia':fmt_float(row_val.get('frequency'),2),
         'Tiempo RV (s)':f"{fmt_float(row_val.get('rtime'),1)}s",
@@ -948,7 +954,7 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
     log_func("\n  **Detalle Top Ads Histórico:** Muestra los anuncios con mejor rendimiento histórico, ordenados primero por mayor gasto total y luego por ROAS más alto. Todas las métricas son acumuladas globales.");
     log_func("  ---")
 
-def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, log_func, detected_currency, top_n=15):
+def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_days_total_ad_df, log_func, detected_currency, top_n=15):
     """Genera una tabla con los top Ads por alcance ordenados por ROAS.
 
     Muestra las principales métricas para tres periodos de 7 días (semana actual
@@ -974,7 +980,10 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, log_fun
 
     period_metrics = {}
     for start_dt, end_dt, label in periods_to_use:
-        df_p = df_daily_agg[(df_daily_agg['date'] >= start_dt) & (df_daily_agg['date'] <= end_dt)].copy()
+        df_p = df_daily_agg[
+            (df_daily_agg['date'].dt.date >= start_dt.date()) &
+            (df_daily_agg['date'].dt.date <= end_dt.date())
+        ].copy()
         if df_p.empty:
             period_metrics[label] = pd.DataFrame(columns=group_cols)
             continue
@@ -1008,31 +1017,40 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, log_fun
         period_metrics[label] = df_g
 
     if not period_metrics[period_labels[0]].empty:
-        ranking_df = period_metrics[period_labels[0]].sort_values(['reach', 'roas'], ascending=[False, False]).head(top_n)
+        ranking_df = period_metrics[period_labels[0]].copy()
+        ranking_df['rank_score'] = ranking_df['roas'] * ranking_df['reach']
+        if active_days_total_ad_df is not None and not active_days_total_ad_df.empty:
+            merge_cols=[c for c in group_cols if c in active_days_total_ad_df.columns]
+            if merge_cols:
+                ranking_df=pd.merge(ranking_df, active_days_total_ad_df[merge_cols+['Días_Activo_Total']], on=merge_cols, how='left')
+        ranking_df = ranking_df.sort_values('rank_score', ascending=False).head(top_n)
+        ranking_df['Días_Activo_Total']=ranking_df.get('Días_Activo_Total',0).fillna(0).astype(int)
     else:
         log_func("\nNo hay datos para la semana actual. Top Ads Bitácora omitido.")
         return
 
 
     log_func(f"\n** Top {top_n} Ads Bitácora (Reach Desc, ROAS Desc)**")
-    top_keys = ranking_df[group_cols]
+    top_keys = ranking_df[group_cols + ['Días_Activo_Total']]
 
     header = (
-        "Período\tROAS\tInversión\tCompras\tCPA\tAlcance\tImpresiones\tCTR"
+        "Período\tROAS\tInversión\tCompras\tNCPA\tCVR\tAOV\tAlcance\tImpresiones\tCTR"
     )
 
     for _, key_row in top_keys.iterrows():
         camp = key_row.get('Campaign', '-')
         adset = key_row.get('AdSet', '-')
         ad = key_row.get('Anuncio', '-')
+        dias_act = int(key_row.get('Días_Activo_Total', 0))
         log_func(f"\nAnuncio: {ad}")
         log_func(f"Campaña: {camp}")
         log_func(f"AdSet: {adset}")
+        log_func(f"Días Activos: {dias_act}")
         log_func(header)
         for label in period_labels:
             df_metrics = period_metrics.get(label)
             if df_metrics is None or df_metrics.empty:
-                log_func(f"{label}\t-\t-\t-\t-\t-\t-\t-")
+                log_func(f"{label}\t-\t-\t-\t-\t-\t-\t-\t-\t-")
                 continue
             sel = df_metrics[
                 (df_metrics['Campaign'] == camp) &
@@ -1040,18 +1058,20 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, log_fun
                 (df_metrics['Anuncio'] == ad)
             ]
             if sel.empty:
-                log_func(f"{label}\t-\t-\t-\t-\t-\t-\t-")
+                log_func(f"{label}\t-\t-\t-\t-\t-\t-\t-\t-\t-")
                 continue
             r_row = sel.iloc[0]
             roas = f"{fmt_float(r_row.get('roas'),2)}x"
             spend = f"{detected_currency}{fmt_float(r_row.get('spend'),2)}"
             purchases = fmt_int(r_row.get('purchases'))
-            cpa = f"{detected_currency}{fmt_float(r_row.get('cpa'),2)}"
+            ncpa = f"{detected_currency}{fmt_float(safe_division(r_row.get('spend'), r_row.get('purchases')),2)}"
+            cvr = fmt_pct(safe_division_pct(r_row.get('purchases'), r_row.get('visits')),2)
+            aov = f"{detected_currency}{fmt_float(safe_division(r_row.get('value'), r_row.get('purchases')),2)}"
             reach = fmt_int(r_row.get('reach'))
             impr = fmt_int(r_row.get('impr'))
             ctr = fmt_pct(r_row.get('ctr'),2)
             log_func(
-                f"{label}\t{roas}\t{spend}\t{purchases}\t{cpa}\t{reach}\t{impr}\t{ctr}"
+                f"{label}\t{roas}\t{spend}\t{purchases}\t{ncpa}\t{cvr}\t{aov}\t{reach}\t{impr}\t{ctr}"
             )
 
 

--- a/formatting_utils.py
+++ b/formatting_utils.py
@@ -70,17 +70,18 @@ def safe_division(n_input, d_input):
     return_scalar = not isinstance(n_input, (pd.Series, np.ndarray)) and \
                     not isinstance(d_input, (pd.Series, np.ndarray))
     mask = pd.notna(n) & pd.notna(d) & np.isfinite(n) & np.isfinite(d) & (abs(d) > 1e-9)
-    result_values = np.where(mask, n / d, np.nan)
+    n_arr = np.asarray(n, dtype=float)
+    d_arr = np.asarray(d, dtype=float)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        result_values = np.divide(n_arr, d_arr, out=np.full_like(n_arr, np.nan, dtype=float), where=mask)
     if return_scalar:
-        try: return result_values.item()
-        except IndexError: return np.nan
-        except ValueError: return result_values[0].item() if result_values.size > 0 else np.nan
+        return result_values.item() if result_values.size > 0 else np.nan
     else:
         index = n_input.index if isinstance(n_input, pd.Series) else \
                 (d_input.index if isinstance(d_input, pd.Series) else None)
         name = (n_input.name + "_div" if isinstance(n_input, pd.Series) and n_input.name else
                 (d_input.name + "_denom_div" if isinstance(d_input, pd.Series) and d_input.name else None))
-        return pd.Series(result_values.flatten(), index=index, name=name)
+        return pd.Series(result_values, index=index, name=name)
 
 def safe_division_pct(n_input, d_input):
     """Safely divide and multiply result by 100 to express a percentage."""
@@ -89,17 +90,18 @@ def safe_division_pct(n_input, d_input):
     return_scalar = not isinstance(n_input, (pd.Series, np.ndarray)) and \
                     not isinstance(d_input, (pd.Series, np.ndarray))
     mask = pd.notna(n) & pd.notna(d) & np.isfinite(n) & np.isfinite(d) & (abs(d) > 1e-9)
-    result_values = np.where(mask, (n / d) * 100, np.nan)
+    n_arr = np.asarray(n, dtype=float)
+    d_arr = np.asarray(d, dtype=float)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        result_values = np.divide(n_arr, d_arr, out=np.full_like(n_arr, np.nan, dtype=float), where=mask) * 100
     if return_scalar:
-        try: return result_values.item()
-        except IndexError: return np.nan
-        except ValueError: return result_values[0].item() if result_values.size > 0 else np.nan
+        return result_values.item() if result_values.size > 0 else np.nan
     else:
         index = n_input.index if isinstance(n_input, pd.Series) else \
                 (d_input.index if isinstance(d_input, pd.Series) else None)
         name = (n_input.name + "_pct" if isinstance(n_input, pd.Series) and n_input.name else
                 (d_input.name + "_denom_pct" if isinstance(d_input, pd.Series) and d_input.name else None))
-        return pd.Series(result_values.flatten(), index=index, name=name)
+        return pd.Series(result_values, index=index, name=name)
 # --- FIN DE FUNCIONES IMPORTANTES ---
 
 def _format_dataframe_to_markdown(df, title, log_func, float_cols_fmt={}, int_cols=[], pct_cols_fmt={}, currency_cols={}, stability_cols=[], default_prec=2, max_col_width=None, numeric_cols_for_alignment=[]):

--- a/tests/test_formatting_utils.py
+++ b/tests/test_formatting_utils.py
@@ -8,7 +8,8 @@ def test_safe_division_scalar():
 
 def test_safe_division_series():
     result = safe_division(pd.Series([1, 2]), pd.Series([2, 0]))
-    assert result.tolist() == [0.5, np.nan]
+    assert result.iloc[0] == 0.5
+    assert np.isnan(result.iloc[1])
 
 def test_safe_division_pct():
     assert safe_division_pct(1, 2) == 50.0


### PR DESCRIPTION
## Summary
- support new metrics `cvr`, `aov` and `ncpa`
- compute these metrics during daily aggregation
- show them in ads performance tables and in the top ads reports
- rank Bitácora Top Ads using ROAS weighted by reach and include active days
- compute active days in the bitácora report
- fix tests for strict NaN equality
- ensure weekly filtering uses date-only comparison

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aceaab7a0833289fcd3f2707396f2