### PR TITLE
Improve active day calculation and audience metrics

### DIFF
--- a/data_processing/metric_calculators.py
+++ b/data_processing/metric_calculators.py
@@ -10,11 +10,26 @@ from formatting_utils import safe_division, safe_division_pct # De formatting_ut
 def _calcular_dias_activos_totales(df_combined):
     """Return number of active days per campaign, ad set and ad."""
     results={'Campaign':pd.DataFrame(columns=['Campaign','Días_Activo_Total']),'AdSet':pd.DataFrame(columns=['Campaign','AdSet','Días_Activo_Total']),'Anuncio':pd.DataFrame(columns=['Campaign','AdSet','Anuncio','Días_Activo_Total'])}
-    if df_combined is None or df_combined.empty: print("Adv: DF vacío (días activos)."); return results
-    if 'Entrega' not in df_combined.columns: print("Adv: Col 'Entrega' no encontrada (días activos)."); return results
-    active_df=df_combined[df_combined['Entrega'].eq('Activo')].copy()
-    if active_df.empty: print("Adv: No hay filas con estado 'Activo'."); return results
-    if 'date' not in active_df.columns or not pd.api.types.is_datetime64_any_dtype(active_df['date']): print("Adv: Col 'date' inválida."); return results
+    if df_combined is None or df_combined.empty:
+        print("Adv: DF vacío (días activos).")
+        return results
+
+    if 'date' not in df_combined.columns or not pd.api.types.is_datetime64_any_dtype(df_combined['date']):
+        print("Adv: Col 'date' inválida.")
+        return results
+
+    active_df = df_combined.copy()
+
+    if 'Entrega' in active_df.columns:
+        active_df = active_df[active_df['Entrega'].eq('Activo')]
+
+    if 'impr' in active_df.columns:
+        impr_num = pd.to_numeric(active_df['impr'], errors='coerce').fillna(0)
+        active_df = active_df[impr_num > 0]
+
+    if active_df.empty:
+        print("Adv: No hay filas consideradas activas para conteo de días.")
+        return results
 
     if 'Campaign' in active_df.columns: active_df['Campaign'] = active_df['Campaign'].astype(str)
     if 'AdSet' in active_df.columns: active_df['AdSet'] = active_df['AdSet'].astype(str)

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -793,12 +793,14 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
          log_func("Adv: No se pudo ordenar por gasto (columna ausente).")
          df_ads_sorted_spend = filtered_ads.copy()
 
-    t1_headers=['Campaña','AdSet','Nombre ADs','dias','Estado','Alcance','ROAS','Compras','CVR (%)','AOV','NCPA','CPM','CTR','CTR Saliente','Var U7 CTR','Var U7 ROAS','Var U7 Freq','Var U7 CPM','Var U7 Compras']
+    t1_headers=['Campaña','AdSet','Nombre ADs','Públicos Incluidos','Públicos Excluidos','dias','Estado','Alcance','ROAS','Compras','CVR (%)','AOV','NCPA','CPM','CTR','CTR Saliente','Var U7 CTR','Var U7 ROAS','Var U7 Freq','Var U7 CPM','Var U7 Compras']
     t1_data=[]
     for _,r_row in df_ads_sorted_spend.iterrows(): t1_data.append({
         'Campaña':r_row.get('Campaign','-'),
         'AdSet':r_row.get('AdSet','-'),
         'Nombre ADs':r_row.get('Anuncio','-'),
+        'Públicos Incluidos':str(r_row.get('Públicos In_global','-')),
+        'Públicos Excluidos':str(r_row.get('Públicos Ex_global','-')),
         'dias':fmt_int(r_row.get('Días_Activo_Total', 0)),
         'Estado':r_row.get('Estado_Ult_Dia','-'),
         'Alcance':fmt_int(r_row.get('reach_global')),
@@ -819,7 +821,7 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
     if t1_data: 
         df_t1=pd.DataFrame(t1_data)
         df_t1 = df_t1[[h for h in t1_headers if h in df_t1.columns]] 
-        num_cols_t1=[h for h in df_t1.columns if h not in ['Campaña','AdSet','Nombre ADs','Estado']] 
+        num_cols_t1=[h for h in df_t1.columns if h not in ['Campaña','AdSet','Nombre ADs','Estado','Públicos Incluidos','Públicos Excluidos']]
         _format_dataframe_to_markdown(df_t1,f"** Tabla Ads: Rendimiento y Variación (Orden: Gasto Desc) **",log_func,currency_cols=detected_currency, numeric_cols_for_alignment=num_cols_t1, max_col_width=45)
         log_func("\n  **Detalle Tabla Ads: Rendimiento y Variación:**");
         log_func("  * **Columnas principales (Alcance, ROAS, etc.):** Muestran el valor *Global Acumulado* para cada Ad durante todo el período de datos analizado.")
@@ -842,12 +844,14 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
     else: 
          log_func("Adv: No se pudo ordenar por ROAS/Reach/Días (columnas ausentes).")
 
-    t2_headers=['Campaña','AdSet','Nombre Ads','dias','Estado','CTR Glob (%)','Tiempo RV (s)','% RV 25','% RV 75','% RV 100','CPM Stab U7 (%)','Públicos Incluidos','Públicos Excluidos']
+    t2_headers=['Campaña','AdSet','Nombre Ads','Públicos Incluidos','Públicos Excluidos','dias','Estado','CTR Glob (%)','Tiempo RV (s)','% RV 25','% RV 75','% RV 100','CPM Stab U7 (%)']
     t2_data=[]
     for _,r_row in df_ads_sorted_roas.iterrows(): t2_data.append({
         'Campaña':r_row.get('Campaign','-'),
         'AdSet':r_row.get('AdSet','-'),
         'Nombre Ads':r_row.get('Anuncio','-'),
+        'Públicos Incluidos':str(r_row.get('Públicos In_global','-')),
+        'Públicos Excluidos':str(r_row.get('Públicos Ex_global','-')),
         'dias':fmt_int(r_row.get('Días_Activo_Total', 0)),
         'Estado':r_row.get('Estado_Ult_Dia','-'),
         'CTR Glob (%)':fmt_pct(r_row.get('ctr_global'),2),
@@ -855,9 +859,7 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
         '% RV 25':fmt_pct(r_row.get('rv25_pct_global'),1),
         '% RV 75':fmt_pct(r_row.get('rv75_pct_global'),1),
         '% RV 100':fmt_pct(r_row.get('rv100_pct_global'),1),
-        'CPM Stab U7 (%)':fmt_stability(r_row.get('cpm_stability_u7')),
-        'Públicos Incluidos':str(r_row.get('Públicos In_global','-')), 
-        'Públicos Excluidos':str(r_row.get('Públicos Ex_global','-')) 
+        'CPM Stab U7 (%)':fmt_stability(r_row.get('cpm_stability_u7'))
         })
     if t2_data: 
         df_t2=pd.DataFrame(t2_data)
@@ -975,7 +977,9 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
     agg_dict = {
         'spend': 'sum', 'value': 'sum', 'purchases': 'sum', 'clicks': 'sum',
         'clicks_out': 'sum', 'impr': 'sum', 'reach': 'sum', 'visits': 'sum',
-        'rv3': 'sum', 'rv25': 'sum', 'rv75': 'sum', 'rv100': 'sum', 'rtime': 'mean'
+        'rv3': 'sum', 'rv25': 'sum', 'rv75': 'sum', 'rv100': 'sum', 'rtime': 'mean',
+        'Públicos In': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
+        'Públicos Ex': lambda x: aggregate_strings(x, separator=' | ', max_len=None)
     }
 
     period_metrics = {}
@@ -1031,7 +1035,7 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
 
 
     log_func(f"\n** Top {top_n} Ads Bitácora (Reach Desc, ROAS Desc)**")
-    top_keys = ranking_df[group_cols + ['Días_Activo_Total']]
+    top_keys = ranking_df[group_cols + ['Públicos In', 'Públicos Ex', 'Días_Activo_Total']]
 
     header = (
         "Período\tROAS\tInversión\tCompras\tNCPA\tCVR\tAOV\tAlcance\tImpresiones\tCTR"
@@ -1041,10 +1045,14 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
         camp = key_row.get('Campaign', '-')
         adset = key_row.get('AdSet', '-')
         ad = key_row.get('Anuncio', '-')
+        pub_in = key_row.get('Públicos In', '-')
+        pub_ex = key_row.get('Públicos Ex', '-')
         dias_act = int(key_row.get('Días_Activo_Total', 0))
         log_func(f"\nAnuncio: {ad}")
         log_func(f"Campaña: {camp}")
         log_func(f"AdSet: {adset}")
+        log_func(f"Públicos Incluidos: {pub_in}")
+        log_func(f"Públicos Excluidos: {pub_ex}")
         log_func(f"Días Activos: {dias_act}")
         log_func(header)
         for label in period_labels:

--- a/tests/test_metric_calculators.py
+++ b/tests/test_metric_calculators.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from data_processing.metric_calculators import _calcular_dias_activos_totales
+
+
+def test_active_days_impressions_filter():
+    df = pd.DataFrame({
+        'Campaign': ['C1', 'C1', 'C1', 'C1'],
+        'AdSet': ['A1', 'A1', 'A1', 'A1'],
+        'Anuncio': ['Ad1', 'Ad1', 'Ad1', 'Ad1'],
+        'date': pd.to_datetime(['2024-01-01','2024-01-02','2024-01-02','2024-01-03']),
+        'Entrega': ['Activo', 'Activo', 'Apagado', 'Activo'],
+        'impr': [10, 0, 15, 5]
+    })
+    res = _calcular_dias_activos_totales(df)
+    assert res['Anuncio']['Días_Activo_Total'].iloc[0] == 2

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -1,0 +1,45 @@
+import pandas as pd
+from datetime import datetime
+from data_processing.report_sections import _generar_tabla_bitacora_top_ads
+
+
+def test_top_ads_audience_lines(capsys):
+    df = pd.DataFrame({
+        'date': pd.to_datetime(['2024-06-01','2024-06-02']),
+        'Campaign': ['Camp','Camp'],
+        'AdSet': ['Set','Set'],
+        'Anuncio': ['Ad1','Ad1'],
+        'spend': [10, 20],
+        'impr': [100, 200],
+        'reach': [80, 150],
+        'purchases': [1, 2],
+        'visits': [10, 20],
+        'value': [50, 120],
+        'clicks': [5, 10],
+        'clicks_out': [1, 2],
+        'rv3': [0, 0],
+        'rv25': [1, 2],
+        'rv75': [0, 1],
+        'rv100': [0, 1],
+        'rtime': [4, 5],
+        'Públicos In': ['Inc1', 'Inc2'],
+        'Públicos Ex': ['Exc1', 'Exc2'],
+    })
+    periods = [
+        (datetime(2024,6,1), datetime(2024,6,2), 'Semana actual'),
+        (datetime(2024,5,25), datetime(2024,5,31), '1ª semana anterior'),
+        (datetime(2024,5,18), datetime(2024,5,24), '2ª semana anterior'),
+    ]
+    active = pd.DataFrame({
+        'Campaign': ['Camp'],
+        'AdSet': ['Set'],
+        'Anuncio': ['Ad1'],
+        'Días_Activo_Total': [2]
+    })
+    logs = []
+    _generar_tabla_bitacora_top_ads(df, periods, active, logs.append, '$', top_n=1)
+    output = "\n".join(logs)
+    assert 'Públicos Incluidos:' in output
+    assert 'Inc1' in output and 'Inc2' in output
+    assert 'Públicos Excluidos:' in output
+    assert 'Exc1' in output and 'Exc2' in output


### PR DESCRIPTION
## Summary
- correct active day counting based on impressions and active status
- show audience columns before `dias` in Ads tables
- include audience info in Top Ads Bitácora output
- add regression tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae6b8883883328b108d30dd3b07f1