### PR TITLE
Enhance Top Ads table with new metrics

### DIFF
--- a/config.py
+++ b/config.py
@@ -59,6 +59,9 @@ norm_map = {
     'rv75': [normalize('Reproducciones de video hasta el 75%'), normalize('Video plays at 75%'), normalize('Video Plays at 75%')],
     'rv100': [normalize('Reproducciones de video hasta el 100%'), normalize('Video plays at 100%'), normalize('Video Plays at 100%')],
     'rtime': [normalize('Tiempo promedio de reproducción del video'), normalize('Avg. video watch time'), normalize('Average video play time')],
+    'thruplays': [normalize('ThruPlays')],
+    'puja': [normalize('Puja')],
+    'url_final': [normalize('URL del sitio web'), normalize('Website URL')],
 }
 
 numeric_internal_cols = [
@@ -70,6 +73,7 @@ numeric_internal_cols = [
     'addcart', 'checkout', 'purchases', 
     'value', 'value_avg', 'roas', 'cpa', 'ncpa', 'aov', 'cvr',
     'rv3', 'rv25', 'rv75', 'rv100', 'rtime' # Video
+    ,'thruplays','puja'
 ]
 
 # Símbolos de moneda preferidos (puedes expandir esto)

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -47,11 +47,11 @@ This document lists the columns present in the imported Excel reports and how th
 | Reacciones a publicaciones | - | numeric | not used |
 | Veces que se guardaron las publicaciones | - | numeric | not used |
 | Veces que se compartieron las publicaciones | - | numeric | not used |
-| ThruPlays | - | numeric | not used |
+| ThruPlays | thruplays | numeric | mapped via `norm_map` |
 | CTR único (todos) | ctr_unico_todos | numeric | mapped via `norm_map` |
-| Puja | - | string | not used |
+| Puja | puja | numeric | mapped via `norm_map` |
 | Tipo de puja | - | string | not used |
-| URL del sitio web | - | string | not used |
+| URL del sitio web | url_final | string | mapped via `norm_map` |
 | CTR (porcentaje de clics en el enlace) | - | numeric | not used |
 | Divisa | - | string | not used; symbol extracted from `Importe gastado` |
 | Interes | interest | numeric | mapped via `norm_map` |

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from datetime import datetime
 from data_processing.report_sections import _generar_tabla_bitacora_top_ads
+from data_processing.report_sections import _clean_audience_string
 
 
 def test_top_ads_audience_lines(capsys):
@@ -43,3 +44,6 @@ def test_top_ads_audience_lines(capsys):
     assert 'Inc1' in output and 'Inc2' in output
     assert 'Públicos Excluidos:' in output
     assert 'Exc1' in output and 'Exc2' in output
+
+def test_clean_audience_string():
+    assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'


### PR DESCRIPTION
## Summary
- map ThruPlays, Puja and URL FINAL fields
- include those metrics in Top Ads tables
- add audience string cleaning helper and apply it
- document new column mappings
- test audience cleaner

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af34fa64083329c5df2d99d09c00e