### PR TITLE
Enhance Top Ads Bitácora metrics

### DIFF
--- a/config.py
+++ b/config.py
@@ -59,6 +59,11 @@ norm_map = {
     'rv75': [normalize('Reproducciones de video hasta el 75%'), normalize('Video plays at 75%'), normalize('Video Plays at 75%')],
     'rv100': [normalize('Reproducciones de video hasta el 100%'), normalize('Video plays at 100%'), normalize('Video Plays at 100%')],
     'rtime': [normalize('Tiempo promedio de reproducción del video'), normalize('Avg. video watch time'), normalize('Average video play time')],
+    'thruplays': [normalize('ThruPlays')],
+    'puja': [normalize('Puja')],
+    'url_final': [normalize('URL del sitio web'), normalize('Website URL')],
+    'interacciones': [normalize('Interacciones con la publicación'), normalize('Post interactions')],
+    'comentarios': [normalize('Comentarios de publicaciones'), normalize('Post comments')],
 }
 
 numeric_internal_cols = [
@@ -70,6 +75,7 @@ numeric_internal_cols = [
     'addcart', 'checkout', 'purchases', 
     'value', 'value_avg', 'roas', 'cpa', 'ncpa', 'aov', 'cvr',
     'rv3', 'rv25', 'rv75', 'rv100', 'rtime' # Video
+    ,'thruplays','puja','interacciones','comentarios'
 ]
 
 # Símbolos de moneda preferidos (puedes expandir esto)

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -21,6 +21,11 @@ from .metric_calculators import _calcular_metricas_agregadas_y_estabilidad, _cal
 from config import numeric_internal_cols # Importar desde la raíz del proyecto
 from utils import aggregate_strings
 
+def _clean_audience_string(aud_str):
+    parts = [p.strip() for p in str(aud_str).split('|')]
+    cleaned = [re.sub(r'^\s*\d+\s*:\s*', '', p) for p in parts]
+    return ' | '.join(cleaned)
+
 
 # ============================================================
 # GENERACIÓN DE SECCIONES DEL REPORTE
@@ -799,8 +804,8 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
         'Campaña':r_row.get('Campaign','-'),
         'AdSet':r_row.get('AdSet','-'),
         'Nombre ADs':r_row.get('Anuncio','-'),
-        'Públicos Incluidos':str(r_row.get('Públicos In_global','-')),
-        'Públicos Excluidos':str(r_row.get('Públicos Ex_global','-')),
+        'Públicos Incluidos':_clean_audience_string(r_row.get('Públicos In_global','-')),
+        'Públicos Excluidos':_clean_audience_string(r_row.get('Públicos Ex_global','-')),
         'dias':fmt_int(r_row.get('Días_Activo_Total', 0)),
         'Estado':r_row.get('Estado_Ult_Dia','-'),
         'Alcance':fmt_int(r_row.get('reach_global')),
@@ -892,7 +897,12 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         if col in df_daily_agg_copy.columns:
             df_daily_agg_copy[col] = df_daily_agg_copy[col].astype(str)
 
-    agg_dict={'spend':'sum','value':'sum','purchases':'sum','clicks':'sum','visits':'sum','impr':'sum','reach':'sum','rtime':'mean', 'rv3':'sum'}
+    agg_dict={
+        'spend':'sum','value':'sum','purchases':'sum','clicks':'sum','visits':'sum',
+        'impr':'sum','reach':'sum','rtime':'mean','rv3':'sum',
+        'rv25':'sum','rv75':'sum','rv100':'sum','thruplays':'sum','puja':'mean',
+        'url_final':lambda x: aggregate_strings(x, separator=' | ', max_len=None)
+    }
     agg_dict_available={k:v for k,v in agg_dict.items() if k in df_daily_agg_copy.columns} 
     if not agg_dict_available or 'spend' not in agg_dict_available or 'impr' not in agg_dict_available: 
         log_func("   No hay métricas suficientes (falta spend o impr) para agregar para Top Ads."); return
@@ -901,7 +911,17 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
 
     if all(c_col in ads_global for c_col in ['value','spend']): ads_global['roas']=safe_division(ads_global['value'],ads_global['spend'])
     if all(c_col in ads_global for c_col in ['clicks','impr']): ads_global['ctr']=safe_division_pct(ads_global['clicks'],ads_global['impr'])
-    if all(c_col in ads_global for c_col in ['impr','reach']): ads_global['frequency']=safe_division(ads_global['impr'],ads_global['reach'])
+    if all(c_col in ads_global for c_col in ['impr','reach']):
+        ads_global['frequency']=safe_division(ads_global['impr'],ads_global['reach'])
+    base_rv_col = 'rv3' if 'rv3' in ads_global.columns and ads_global['rv3'].sum() > 0 else 'impr'
+    if base_rv_col in ads_global.columns:
+        base_sum = ads_global[base_rv_col]
+        if 'rv25' in ads_global.columns:
+            ads_global['rv25_pct'] = safe_division_pct(ads_global['rv25'], base_sum)
+        if 'rv75' in ads_global.columns:
+            ads_global['rv75_pct'] = safe_division_pct(ads_global['rv75'], base_sum)
+        if 'rv100' in ads_global.columns:
+            ads_global['rv100_pct'] = safe_division_pct(ads_global['rv100'], base_sum)
     if active_days_total_ad_df is not None and not active_days_total_ad_df.empty and 'Días_Activo_Total' in active_days_total_ad_df.columns:
         merge_cols=[c_col for c_col in group_cols_ad if c_col in active_days_total_ad_df.columns] 
         if merge_cols:
@@ -930,12 +950,26 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         log_func("   No se pudo ordenar Top Ads (faltan columnas spend/roas). Mostrando los primeros {top_n}.")
         df_top=df_top.head(top_n)
 
-    table_headers=['Campaña','AdSet','Anuncio','Días Act','Gasto','ROAS','Compras','CVR (%)','AOV','NCPA','CTR (%)','Frecuencia','Tiempo RV (s)']
+    table_headers=[
+        'Campaña','AdSet','Anuncio','URL FINAL','Puja','ThruPlays',
+        'Reproducciones 25%','Reproducciones 75%','Reproducciones 100%',
+        'Tiempo RV (s)','Días Act','Gasto','ROAS','Compras','CVR (%)','AOV','NCPA','CTR (%)','Frecuencia'
+    ]
+
     table_data=[]
-    for _,row_val in df_top.iterrows(): table_data.append({
+    for _,row_val in df_top.iterrows():
+        rv_cols_present = any(row_val.get(c,0)>0 for c in ['rv25','rv75','rv100']) or row_val.get('rtime',0)>0
+        table_data.append({
         'Campaña':row_val.get('Campaign','-'),
         'AdSet':row_val.get('AdSet','-'),
         'Anuncio':row_val.get('Anuncio','-'),
+        'URL FINAL':row_val.get('url_final','-'),
+        'Puja':f"{detected_currency}{fmt_float(row_val.get('puja'),2)}" if pd.notna(row_val.get('puja')) else '-',
+        'ThruPlays':fmt_int(row_val.get('thruplays')),
+        'Reproducciones 25%':fmt_int(row_val.get('rv25')) if rv_cols_present else '-',
+        'Reproducciones 75%':fmt_int(row_val.get('rv75')) if rv_cols_present else '-',
+        'Reproducciones 100%':fmt_int(row_val.get('rv100')) if rv_cols_present else '-',
+        'Tiempo RV (s)':f"{fmt_float(row_val.get('rtime'),1)}s" if rv_cols_present else '-',
         'Días Act':fmt_int(row_val.get('Días_Activo_Total', 0)),
         'Gasto':f"{detected_currency}{fmt_float(row_val.get('spend'),0)}",
         'ROAS':f"{fmt_float(row_val.get('roas'),2)}x",
@@ -945,12 +979,11 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         'NCPA':f"{detected_currency}{fmt_float(safe_division(row_val.get('spend'), row_val.get('purchases')),2)}",
         'CTR (%)':fmt_pct(row_val.get('ctr'),2),
         'Frecuencia':fmt_float(row_val.get('frequency'),2),
-        'Tiempo RV (s)':f"{fmt_float(row_val.get('rtime'),1)}s",
         })
     if table_data: 
         df_display=pd.DataFrame(table_data)
         df_display = df_display[[h for h in table_headers if h in df_display.columns]] 
-        num_cols=[h for h in df_display.columns if h not in ['Campaña','AdSet','Anuncio']] 
+        num_cols=[h for h in df_display.columns if h not in ['Campaña','AdSet','Anuncio','URL FINAL']]
         _format_dataframe_to_markdown(df_display,f"** Top {top_n} Ads por Gasto > ROAS (Global Acumulado) **",log_func,currency_cols=detected_currency, stability_cols=[], numeric_cols_for_alignment=num_cols)
     else: log_func(f"   No hay datos para mostrar en Top {top_n} Ads.");
     log_func("\n  **Detalle Top Ads Histórico:** Muestra los anuncios con mejor rendimiento histórico, ordenados primero por mayor gasto total y luego por ROAS más alto. Todas las métricas son acumuladas globales.");
@@ -978,6 +1011,8 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
         'spend': 'sum', 'value': 'sum', 'purchases': 'sum', 'clicks': 'sum',
         'clicks_out': 'sum', 'impr': 'sum', 'reach': 'sum', 'visits': 'sum',
         'rv3': 'sum', 'rv25': 'sum', 'rv75': 'sum', 'rv100': 'sum', 'rtime': 'mean',
+        'thruplays': 'sum', 'puja': 'mean', 'interacciones': 'sum', 'comentarios': 'sum',
+        'url_final': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
         'Públicos In': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
         'Públicos Ex': lambda x: aggregate_strings(x, separator=' | ', max_len=None)
     }
@@ -1035,7 +1070,8 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
 
 
     log_func(f"\n** Top {top_n} Ads Bitácora (Reach Desc, ROAS Desc)**")
-    top_keys = ranking_df[group_cols + ['Públicos In', 'Públicos Ex', 'Días_Activo_Total']]
+    extra_cols = [c for c in ['url_final','puja','interacciones','comentarios','rtime'] if c in ranking_df.columns]
+    top_keys = ranking_df[group_cols + ['Públicos In', 'Públicos Ex'] + extra_cols + ['Días_Activo_Total']]
 
     header = (
         "Período\tROAS\tInversión\tCompras\tNCPA\tCVR\tAOV\tAlcance\tImpresiones\tCTR"
@@ -1045,14 +1081,29 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
         camp = key_row.get('Campaign', '-')
         adset = key_row.get('AdSet', '-')
         ad = key_row.get('Anuncio', '-')
-        pub_in = key_row.get('Públicos In', '-')
-        pub_ex = key_row.get('Públicos Ex', '-')
+        pub_in = _clean_audience_string(key_row.get('Públicos In', '-'))
+        pub_ex = _clean_audience_string(key_row.get('Públicos Ex', '-'))
+        url = key_row.get('url_final', '-')
+        puja_val = key_row.get('puja', np.nan)
+        interac = key_row.get('interacciones', np.nan)
+        coments = key_row.get('comentarios', np.nan)
+        rtime_val = key_row.get('rtime', np.nan)
         dias_act = int(key_row.get('Días_Activo_Total', 0))
         log_func(f"\nAnuncio: {ad}")
         log_func(f"Campaña: {camp}")
         log_func(f"AdSet: {adset}")
         log_func(f"Públicos Incluidos: {pub_in}")
         log_func(f"Públicos Excluidos: {pub_ex}")
+        if 'url_final' in key_row.index:
+            log_func(f"URL: {url}")
+        if 'puja' in key_row.index:
+            log_func(f"Puja: {detected_currency}{fmt_float(puja_val,2)}" if pd.notna(puja_val) else "Puja: -")
+        if 'interacciones' in key_row.index:
+            log_func(f"Interacciones: {fmt_int(interac)}")
+        if 'comentarios' in key_row.index:
+            log_func(f"Comentarios: {fmt_int(coments)}")
+        if 'rtime' in key_row.index:
+            log_func(f"Tiempo promedio de reproducción del video: {fmt_float(rtime_val,1)}s" if pd.notna(rtime_val) else "Tiempo promedio de reproducción del video: -")
         log_func(f"Días Activos: {dias_act}")
         log_func(header)
         for label in period_labels:

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -42,16 +42,16 @@ This document lists the columns present in the imported Excel reports and how th
 | Clics en el enlace | clicks | numeric | mapped via `norm_map` |
 | Información de pago agregada | checkout | numeric | mapped via `norm_map` (as part of checkout metrics) |
 | Interacción con la página | - | numeric | not used |
-| Comentarios de publicaciones | - | numeric | not used |
-| Interacciones con la publicación | - | numeric | not used |
+| Comentarios de publicaciones | comentarios | numeric | mapped via `norm_map` |
+| Interacciones con la publicación | interacciones | numeric | mapped via `norm_map` |
 | Reacciones a publicaciones | - | numeric | not used |
 | Veces que se guardaron las publicaciones | - | numeric | not used |
 | Veces que se compartieron las publicaciones | - | numeric | not used |
-| ThruPlays | - | numeric | not used |
+| ThruPlays | thruplays | numeric | mapped via `norm_map` |
 | CTR único (todos) | ctr_unico_todos | numeric | mapped via `norm_map` |
-| Puja | - | string | not used |
+| Puja | puja | numeric | mapped via `norm_map` |
 | Tipo de puja | - | string | not used |
-| URL del sitio web | - | string | not used |
+| URL del sitio web | url_final | string | mapped via `norm_map` |
 | CTR (porcentaje de clics en el enlace) | - | numeric | not used |
 | Divisa | - | string | not used; symbol extracted from `Importe gastado` |
 | Interes | interest | numeric | mapped via `norm_map` |

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from datetime import datetime
 from data_processing.report_sections import _generar_tabla_bitacora_top_ads
+from data_processing.report_sections import _clean_audience_string
 
 
 def test_top_ads_audience_lines(capsys):
@@ -22,6 +23,10 @@ def test_top_ads_audience_lines(capsys):
         'rv75': [0, 1],
         'rv100': [0, 1],
         'rtime': [4, 5],
+        'url_final': ['https://a.com','https://a.com'],
+        'puja': [1.2, 1.3],
+        'interacciones': [3,4],
+        'comentarios': [1,1],
         'Públicos In': ['Inc1', 'Inc2'],
         'Públicos Ex': ['Exc1', 'Exc2'],
     })
@@ -43,3 +48,11 @@ def test_top_ads_audience_lines(capsys):
     assert 'Inc1' in output and 'Inc2' in output
     assert 'Públicos Excluidos:' in output
     assert 'Exc1' in output and 'Exc2' in output
+    assert 'URL:' in output
+    assert 'Puja:' in output
+    assert 'Interacciones:' in output
+    assert 'Comentarios:' in output
+    assert 'Tiempo promedio de reproducción del video:' in output
+
+def test_clean_audience_string():
+    assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'


### PR DESCRIPTION
## Summary
- map Interacciones and Comentarios columns
- aggregate new metrics for Top Ads Bitácora
- display URL, Puja, Interacciones, Comentarios and average video time
- update docs and tests

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af34fa64083329c5df2d99d09c00e