### PR TITLE
Add mapping for extra metrics and aggregate them

### DIFF
--- a/config.py
+++ b/config.py
@@ -62,6 +62,8 @@ norm_map = {
     'thruplays': [normalize('ThruPlays')],
     'puja': [normalize('Puja')],
     'url_final': [normalize('URL del sitio web'), normalize('Website URL')],
+    'interacciones': [normalize('Interacciones con la publicación'), normalize('Post engagement')],
+    'comentarios': [normalize('Comentarios de publicaciones'), normalize('Post comments')],
 }
 
 numeric_internal_cols = [
@@ -73,7 +75,7 @@ numeric_internal_cols = [
     'addcart', 'checkout', 'purchases', 
     'value', 'value_avg', 'roas', 'cpa', 'ncpa', 'aov', 'cvr',
     'rv3', 'rv25', 'rv75', 'rv100', 'rtime' # Video
-    ,'thruplays','puja'
+    ,'thruplays','puja','interacciones','comentarios'
 ]
 
 # Símbolos de moneda preferidos (puedes expandir esto)

--- a/data_processing/aggregators.py
+++ b/data_processing/aggregators.py
@@ -42,6 +42,8 @@ def _agregar_datos_diarios(df_combined, status_queue, selected_adsets=None):
             'visits':'sum','clicks_out':'sum', 'rv3':'sum','rv25':'sum','rv75':'sum','rv100':'sum',
             'attention':'sum','interest':'sum','deseo':'sum','addcart':'sum','checkout':'sum',
             'rtime':'mean','freq':'mean','roas':'mean','cpa':'mean',
+            'puja':'mean','interacciones':'sum','comentarios':'sum',
+            'url_final':lambda x:aggregate_strings(x,separator=' | ',max_len=None),
             'Públicos In':lambda x:aggregate_strings(x,separator=' | ',max_len=None),
             'Públicos Ex':lambda x:aggregate_strings(x,separator=' | ',max_len=None),
             'Entrega':lambda x:aggregate_strings(x,separator='|',max_len=50)

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -1011,6 +1011,8 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
         'spend': 'sum', 'value': 'sum', 'purchases': 'sum', 'clicks': 'sum',
         'clicks_out': 'sum', 'impr': 'sum', 'reach': 'sum', 'visits': 'sum',
         'rv3': 'sum', 'rv25': 'sum', 'rv75': 'sum', 'rv100': 'sum', 'rtime': 'mean',
+        'puja': 'mean', 'interacciones': 'sum', 'comentarios': 'sum',
+        'url_final': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
         'Públicos In': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
         'Públicos Ex': lambda x: aggregate_strings(x, separator=' | ', max_len=None)
     }
@@ -1078,12 +1080,39 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
         camp = key_row.get('Campaign', '-')
         adset = key_row.get('AdSet', '-')
         ad = key_row.get('Anuncio', '-')
+        latest_row = ranking_df[
+            (ranking_df['Campaign'] == camp) &
+            (ranking_df['AdSet'] == adset) &
+            (ranking_df['Anuncio'] == ad)
+        ]
+        if not latest_row.empty:
+            latest_row = latest_row.iloc[0]
+            url_final = latest_row.get('url_final', '-')
+            puja_val = latest_row.get('puja')
+            interacciones_val = latest_row.get('interacciones')
+            comentarios_val = latest_row.get('comentarios')
+            rtime_val = latest_row.get('rtime')
+        else:
+            url_final = '-'
+            puja_val = np.nan
+            interacciones_val = np.nan
+            comentarios_val = np.nan
+            rtime_val = np.nan
         pub_in = _clean_audience_string(key_row.get('Públicos In', '-'))
         pub_ex = _clean_audience_string(key_row.get('Públicos Ex', '-'))
         dias_act = int(key_row.get('Días_Activo_Total', 0))
         log_func(f"\nAnuncio: {ad}")
         log_func(f"Campaña: {camp}")
         log_func(f"AdSet: {adset}")
+        log_func(f"URL: {url_final}")
+        log_func(
+            f"Puja: {detected_currency}{fmt_float(puja_val,2)}" if pd.notna(puja_val) else "Puja: -"
+        )
+        log_func(f"Interacciones: {fmt_int(interacciones_val)}")
+        log_func(f"Comentarios: {fmt_int(comentarios_val)}")
+        log_func(
+            f"Tiempo promedio de reproducción del video: {fmt_float(rtime_val,1)}s"
+        )
         log_func(f"Públicos Incluidos: {pub_in}")
         log_func(f"Públicos Excluidos: {pub_ex}")
         log_func(f"Días Activos: {dias_act}")

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -42,8 +42,8 @@ This document lists the columns present in the imported Excel reports and how th
 | Clics en el enlace | clicks | numeric | mapped via `norm_map` |
 | Información de pago agregada | checkout | numeric | mapped via `norm_map` (as part of checkout metrics) |
 | Interacción con la página | - | numeric | not used |
-| Comentarios de publicaciones | - | numeric | not used |
-| Interacciones con la publicación | - | numeric | not used |
+| Comentarios de publicaciones | comentarios | numeric | mapped via `norm_map` |
+| Interacciones con la publicación | interacciones | numeric | mapped via `norm_map` |
 | Reacciones a publicaciones | - | numeric | not used |
 | Veces que se guardaron las publicaciones | - | numeric | not used |
 | Veces que se compartieron las publicaciones | - | numeric | not used |

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from queue import SimpleQueue
+from data_processing.aggregators import _agregar_datos_diarios
+
+
+def test_agregar_diarios_includes_extra_fields():
+    df = pd.DataFrame({
+        'date': pd.to_datetime(['2024-06-01', '2024-06-01']),
+        'Campaign': ['Camp', 'Camp'],
+        'AdSet': ['Set', 'Set'],
+        'Anuncio': ['Ad', 'Ad'],
+        'spend': [10, 20],
+        'impr': [100, 200],
+        'reach': [50, 100],
+        'value': [40, 80],
+        'purchases': [1, 2],
+        'clicks': [10, 20],
+        'puja': [1.0, 1.5],
+        'url_final': ['https://a.com', 'https://a.com/page'],
+        'interacciones': [5, 6],
+        'comentarios': [1, 2],
+    })
+
+    q = SimpleQueue()
+    result = _agregar_datos_diarios(df, q)
+    assert 'puja' in result.columns
+    assert 'url_final' in result.columns
+    assert 'interacciones' in result.columns
+    assert 'comentarios' in result.columns
+
+    row = result.iloc[0]
+    assert row['puja'] == 1.25
+    assert row['interacciones'] == 11
+    assert row['comentarios'] == 3
+    assert 'https://a.com' in row['url_final']

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -23,6 +23,10 @@ def test_top_ads_audience_lines(capsys):
         'rv75': [0, 1],
         'rv100': [0, 1],
         'rtime': [4, 5],
+        'url_final': ['https://ex.com', 'https://ex.com'],
+        'puja': [0.5, 0.5],
+        'interacciones': [7, 8],
+        'comentarios': [1, 2],
         'Públicos In': ['Inc1', 'Inc2'],
         'Públicos Ex': ['Exc1', 'Exc2'],
     })
@@ -44,6 +48,11 @@ def test_top_ads_audience_lines(capsys):
     assert 'Inc1' in output and 'Inc2' in output
     assert 'Públicos Excluidos:' in output
     assert 'Exc1' in output and 'Exc2' in output
+    assert 'URL:' in output
+    assert 'Puja:' in output
+    assert 'Interacciones:' in output
+    assert 'Comentarios:' in output
+    assert 'Tiempo promedio de reproducción del video:' in output
 
 def test_clean_audience_string():
     assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'


### PR DESCRIPTION
## Summary
- aggregate Puja, URL, Interacciones and Comentarios in daily aggregator
- cover new metrics with unit test

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af9203a5c833285c064e4c6689c22