### PR TITLE
Map new synonyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ After installing dependencies you can run the unit tests with:
 pytest
 ```
 
+## Report Format
+
+Generated reports are plain text files where tables use a semicolon (`;`) as the delimiter for each cell. This ensures data can be imported directly into spreadsheet tools. See `docs/report_format.md` for details.
+
 ## Contributing
 
 Pull requests that introduce useful scripts, improve documentation, or help define the project structure are welcome. Feel free to open issues to discuss ideas or report problems.

--- a/config.py
+++ b/config.py
@@ -60,10 +60,25 @@ norm_map = {
     'rv100': [normalize('Reproducciones de video hasta el 100%'), normalize('Video plays at 100%'), normalize('Video Plays at 100%')],
     'rtime': [normalize('Tiempo promedio de reproducción del video'), normalize('Avg. video watch time'), normalize('Average video play time')],
     'thruplays': [normalize('ThruPlays')],
-    'puja': [normalize('Puja')],
-    'url_final': [normalize('URL del sitio web'), normalize('Website URL')],
-    'interacciones': [normalize('Interacciones con la publicación'), normalize('Post engagement')],
-    'comentarios': [normalize('Comentarios de publicaciones'), normalize('Post comments')],
+    'puja': [
+        normalize('Puja'),
+        normalize('Bid'),  # sinónimo en inglés
+    ],
+    'url_final': [
+        normalize('URL del sitio web'),
+        normalize('Website URL'),
+        normalize('URL'),  # variante abreviada
+    ],
+    'interacciones': [
+        normalize('Interacciones con la publicación'),
+        normalize('Post engagement'),
+        normalize('Interacciones'),  # nombre corto
+    ],
+    'comentarios': [
+        normalize('Comentarios de publicaciones'),
+        normalize('Post comments'),
+        normalize('Comentarios'),  # nombre corto
+    ],
 }
 
 numeric_internal_cols = [

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -1073,7 +1073,7 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
     top_keys = ranking_df[group_cols + ['Públicos In', 'Públicos Ex', 'Días_Activo_Total']]
 
     header = (
-        "Período\tROAS\tInversión\tCompras\tNCPA\tCVR\tAOV\tAlcance\tImpresiones\tCTR"
+        "Período;ROAS;Inversión;Compras;NCPA;CVR;AOV;Alcance;Impresiones;CTR"
     )
 
     for _, key_row in top_keys.iterrows():
@@ -1120,7 +1120,7 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
         for label in period_labels:
             df_metrics = period_metrics.get(label)
             if df_metrics is None or df_metrics.empty:
-                log_func(f"{label}\t-\t-\t-\t-\t-\t-\t-\t-\t-")
+                log_func(f"{label};-;-;-;-;-;-;-;-;-")
                 continue
             sel = df_metrics[
                 (df_metrics['Campaign'] == camp) &
@@ -1128,7 +1128,7 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
                 (df_metrics['Anuncio'] == ad)
             ]
             if sel.empty:
-                log_func(f"{label}\t-\t-\t-\t-\t-\t-\t-\t-\t-")
+                log_func(f"{label};-;-;-;-;-;-;-;-;-")
                 continue
             r_row = sel.iloc[0]
             roas = f"{fmt_float(r_row.get('roas'),2)}x"
@@ -1141,7 +1141,7 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
             impr = fmt_int(r_row.get('impr'))
             ctr = fmt_pct(r_row.get('ctr'),2)
             log_func(
-                f"{label}\t{roas}\t{spend}\t{purchases}\t{ncpa}\t{cvr}\t{aov}\t{reach}\t{impr}\t{ctr}"
+                f"{label};{roas};{spend};{purchases};{ncpa};{cvr};{aov};{reach};{impr};{ctr}"
             )
 
 

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -42,16 +42,16 @@ This document lists the columns present in the imported Excel reports and how th
 | Clics en el enlace | clicks | numeric | mapped via `norm_map` |
 | Información de pago agregada | checkout | numeric | mapped via `norm_map` (as part of checkout metrics) |
 | Interacción con la página | - | numeric | not used |
-| Comentarios de publicaciones | comentarios | numeric | mapped via `norm_map` |
-| Interacciones con la publicación | interacciones | numeric | mapped via `norm_map` |
+| Comentarios de publicaciones / Comentarios | comentarios | numeric | mapped via `norm_map` |
+| Interacciones con la publicación / Interacciones | interacciones | numeric | mapped via `norm_map` |
 | Reacciones a publicaciones | - | numeric | not used |
 | Veces que se guardaron las publicaciones | - | numeric | not used |
 | Veces que se compartieron las publicaciones | - | numeric | not used |
 | ThruPlays | thruplays | numeric | mapped via `norm_map` |
 | CTR único (todos) | ctr_unico_todos | numeric | mapped via `norm_map` |
-| Puja | puja | numeric | mapped via `norm_map` |
+| Puja | puja | numeric | mapped via `norm_map` (also accepts "Bid") |
 | Tipo de puja | - | string | not used |
-| URL del sitio web | url_final | string | mapped via `norm_map` |
+| URL del sitio web / URL | url_final | string | mapped via `norm_map` |
 | CTR (porcentaje de clics en el enlace) | - | numeric | not used |
 | Divisa | - | string | not used; symbol extracted from `Importe gastado` |
 | Interes | interest | numeric | mapped via `norm_map` |

--- a/docs/report_format.md
+++ b/docs/report_format.md
@@ -1,0 +1,13 @@
+# Report Format
+
+The generated report files are plain text but tables use a semicolon (`;`) as the single delimiter. This ensures:
+
+- Every cell is clearly separated by one symbol.
+- Ad names or other fields may contain spaces or commas without breaking the layout.
+- The `.txt` file can be imported directly into Excel or Google Sheets.
+
+Example header used in the Top Ads section:
+
+```
+Período;ROAS;Inversión;Compras;NCPA;CVR;AOV;Alcance;Impresiones;CTR
+```


### PR DESCRIPTION
## Summary
- add mapping synonyms for Puja, URL, Interacciones and Comentarios
- document synonyms in column reference
- switch bitácora table output to semicolon delimiter
- document delimiter usage in new report format doc

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684afed56eb483328682fc5610105d8d