### PR TITLE
Align Ad and AdSet tables with campaign format

### DIFF
--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -1076,13 +1076,6 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
             camp = key_row.get('Campaign', '-')
             adset = key_row.get('AdSet', '-')
             ad = key_row.get('Anuncio', '-')
-            url_final = key_row.get('url_final', '-')
-            puja_val = key_row.get('puja')
-            interacciones_val = key_row.get('interacciones')
-            comentarios_val = key_row.get('comentarios')
-            rtime_val = key_row.get('rtime')
-            pub_in = _clean_audience_string(key_row.get('Públicos In', '-'))
-            pub_ex = _clean_audience_string(key_row.get('Públicos Ex', '-'))
             dias_act = int(key_row.get('Días_Activo_Total', 0))
 
             sel = df_metrics[
@@ -1110,13 +1103,6 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
                 'Anuncio': ad,
                 'Campaña': camp,
                 'AdSet': adset,
-                'URL FINAL': url_final,
-                'Puja': f"{detected_currency}{fmt_float(puja_val,2)}" if pd.notna(puja_val) else '-',
-                'Interacciones': fmt_int(interacciones_val),
-                'Comentarios': fmt_int(comentarios_val),
-                'Tiempo RV (s)': f"{fmt_float(rtime_val,1)}s" if pd.notna(rtime_val) else '-',
-                'Públicos Incluidos': pub_in,
-                'Públicos Excluidos': pub_ex,
                 'Días Act': dias_act,
             }
             row.update(metrics)
@@ -1124,9 +1110,9 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
 
         if table_rows:
             df_display = pd.DataFrame(table_rows)
-            column_order = ['Anuncio','Campaña','AdSet','URL FINAL','Puja','Interacciones','Comentarios','Tiempo RV (s)','Públicos Incluidos','Públicos Excluidos','Días Act'] + metric_labels
+            column_order = ['Anuncio','Campaña','AdSet','Días Act'] + metric_labels
             df_display = df_display[[c for c in column_order if c in df_display.columns]]
-            num_cols = [c for c in df_display.columns if c not in ['Anuncio','Campaña','AdSet','URL FINAL','Públicos Incluidos','Públicos Excluidos']]
+            num_cols = [c for c in df_display.columns if c not in ['Anuncio','Campaña','AdSet']]
             _format_dataframe_to_markdown(df_display, f"Top {top_n} Ads Bitácora - {label}", log_func, numeric_cols_for_alignment=num_cols)
             any_table = True
 
@@ -1222,8 +1208,6 @@ def _generar_tabla_bitacora_top_adsets(df_daily_agg, bitacora_periods_list, acti
         for _, key_row in ranking_df.iterrows():
             camp = key_row.get('Campaign', '-')
             adset = key_row.get('AdSet', '-')
-            pub_in = _clean_audience_string(key_row.get('Públicos In', '-'))
-            pub_ex = _clean_audience_string(key_row.get('Públicos Ex', '-'))
             dias_act = int(key_row.get('Días_Activo_Total', 0))
 
             sel = df_metrics[
@@ -1249,8 +1233,6 @@ def _generar_tabla_bitacora_top_adsets(df_daily_agg, bitacora_periods_list, acti
             row = {
                 'Campaña': camp,
                 'AdSet': adset,
-                'Públicos Incluidos': pub_in,
-                'Públicos Excluidos': pub_ex,
                 'Días Act': dias_act,
             }
             row.update(metrics)
@@ -1258,9 +1240,9 @@ def _generar_tabla_bitacora_top_adsets(df_daily_agg, bitacora_periods_list, acti
 
         if table_rows:
             df_display = pd.DataFrame(table_rows)
-            column_order = ['Campaña','AdSet','Públicos Incluidos','Públicos Excluidos','Días Act'] + metric_labels
+            column_order = ['Campaña','AdSet','Días Act'] + metric_labels
             df_display = df_display[[c for c in column_order if c in df_display.columns]]
-            num_cols = [c for c in df_display.columns if c not in ['Campaña','AdSet','Públicos Incluidos','Públicos Excluidos']]
+            num_cols = [c for c in df_display.columns if c not in ['Campaña','AdSet']]
             _format_dataframe_to_markdown(df_display, f"Top {top_n} AdSets Bitácora - {label}", log_func, numeric_cols_for_alignment=num_cols)
             any_table = True
 

--- a/docs/report_format.md
+++ b/docs/report_format.md
@@ -6,10 +6,10 @@ The generated report files are plain text but tables use a semicolon (`;`) as th
 - Ad names or other fields may contain spaces or commas without breaking the layout.
 - The `.txt` file can be imported directly into Excel or Google Sheets.
 
-Example header used in the Top Ads section:
+Example header used in the Top Ads section (after entity columns):
 
 ```
 Período;ROAS;Inversión;Compras;NCPA;CVR;AOV;Alcance;Impresiones;CTR
 ```
 
-This delimiter is consistent across the "Top Ads", "Top AdSets" and "Top Campañas" tables generated in the bitácora reports.
+This delimiter is consistent across the "Top Ads", "Top AdSets" and "Top Campañas" tables generated in the bitácora reports. All three sections share the same metric columns (`ROAS`, `Inversión`, `Compras`, `NCPA`, `CVR`, `AOV`, `Alcance`, `Impresiones`, `CTR`) after the entity identifiers.

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -6,7 +6,7 @@ from data_processing.report_sections import _generar_tabla_bitacora_top_campaign
 from data_processing.report_sections import _clean_audience_string
 
 
-def test_top_ads_audience_lines(capsys):
+def test_top_ads_basic_columns(capsys):
     df = pd.DataFrame({
         'date': pd.to_datetime(['2024-06-01','2024-06-02']),
         'Campaign': ['Camp','Camp'],
@@ -46,15 +46,9 @@ def test_top_ads_audience_lines(capsys):
     logs = []
     _generar_tabla_bitacora_top_ads(df, periods, active, logs.append, '$', top_n=1)
     output = "\n".join(logs)
-    assert 'Públicos Incluidos' in output
-    assert 'Públicos Excluidos' in output
-    assert 'Inc1' in output and 'Inc2' in output
-    assert 'Exc1' in output and 'Exc2' in output
-    assert 'URL FINAL' in output
-    assert 'Puja' in output
-    assert 'Interacciones' in output
-    assert 'Comentarios' in output
-    assert 'Tiempo RV (s)' in output
+    assert 'Top 1 Ads Bitácora - Semana actual' in output
+    assert 'Anuncio' in output
+    assert 'Días Act' in output
 
 def test_clean_audience_string():
     assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'
@@ -85,6 +79,7 @@ def test_top_adsets_weekly_table(capsys):
     _generar_tabla_bitacora_top_adsets(df, periods, active, logs.append, '$', top_n=1)
     output = "\n".join(logs)
     assert 'Top 1 AdSets Bitácora - Semana actual' in output
+    assert 'Días Act' in output
 
 
 def test_top_campaigns_weekly_table(capsys):


### PR DESCRIPTION
## Summary
- simplify the bitácora tables for Ads and AdSets
- keep only the entity and `Días Act` before the metric columns
- update docs to clarify common column layout
- adjust tests for the new format

## Testing
- `pip install -q -r requirements.txt`
- `export PYTHONPATH=.`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b206aa4008332854bedc020b5f384