### PR TITLE
Adjust Top Ads and active day calculation

### DIFF
--- a/data_processing/metric_calculators.py
+++ b/data_processing/metric_calculators.py
@@ -20,8 +20,16 @@ def _calcular_dias_activos_totales(df_combined):
 
     active_df = df_combined.copy()
 
-    if 'Entrega' in active_df.columns:
-        active_df = active_df[active_df['Entrega'].eq('Activo')]
+    delivery_col = None
+    for c in ['Entrega', 'entrega', 'Entrega del anuncio']:
+        if c in active_df.columns:
+            delivery_col = c
+            break
+
+    if delivery_col:
+        delivery_lower = active_df[delivery_col].astype(str).str.lower()
+        active_mask = delivery_lower.str.contains('activo') | delivery_lower.str.contains('active')
+        active_df = active_df[active_mask]
 
     if 'impr' in active_df.columns:
         impr_num = pd.to_numeric(active_df['impr'], errors='coerce').fillna(0)

--- a/data_processing/orchestrators.py
+++ b/data_processing/orchestrators.py
@@ -179,7 +179,7 @@ def procesar_reporte_rendimiento(input_files, output_dir, output_filename, statu
             except Exception as e_s5: log(f"\n!!! Error Sección 5 (Análisis Ads): {e_s5} !!!\n{traceback.format_exc()}",importante=True)
             
             log("--- Iniciando Sección 6: Top Ads Histórico ---",importante=True);
-            try: _generar_tabla_top_ads_historico(df_daily_agg,active_days_ad,log,detected_currency) 
+            try: _generar_tabla_top_ads_historico(df_daily_agg,active_days_ad,log,detected_currency, top_n=20)
             except Exception as e_s6: log(f"\n!!! Error Sección 6 (Top Ads): {e_s6} !!!\n{traceback.format_exc()}",importante=True)
 
             log("\n\n============================================================");log("===== Resumen del Proceso =====");log("============================================================")
@@ -485,7 +485,7 @@ def procesar_reporte_bitacora(input_files, output_dir, output_filename, status_q
 
             _generar_tabla_embudo_bitacora(df_daily_total_for_bitacora, bitacora_periods_list, log, detected_currency, period_type=bitacora_comparison_type)
 
-            _generar_tabla_bitacora_top_ads(df_daily_agg_full, bitacora_periods_list, active_days_ad, log, detected_currency)
+            _generar_tabla_bitacora_top_ads(df_daily_agg_full, bitacora_periods_list, active_days_ad, log, detected_currency, top_n=20)
             _generar_tabla_bitacora_top_adsets(df_daily_agg_full, bitacora_periods_list, active_days_adset, log, detected_currency)
             _generar_tabla_bitacora_top_campaigns(df_daily_agg_full, bitacora_periods_list, active_days_campaign, log, detected_currency)
 

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -883,10 +883,10 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
     log_func("\n--- Fin Análisis Consolidado de Ads ---")
 
 
-def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_func, detected_currency, top_n=10):
+def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_func, detected_currency, top_n=20):
     """List historically best performing ads by spend and ROAS."""
 
-    log_func("\n\n============================================================");log_func(f"===== 6. Top {top_n} Ads Histórico (Orden: Gasto Desc > ROAS Desc) =====");log_func("============================================================")
+    log_func("\n\n============================================================");log_func(f"===== 6. Top {top_n} Ads Histórico (Orden: ROAS Desc) =====");log_func("============================================================")
     group_cols_ad=['Campaign','AdSet','Anuncio'] 
     essential_cols = group_cols_ad + ['spend','impr'] 
     if df_daily_agg is None or df_daily_agg.empty or not all(c_col in df_daily_agg.columns for c_col in essential_cols):
@@ -901,7 +901,9 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         'spend':'sum','value':'sum','purchases':'sum','clicks':'sum','visits':'sum',
         'impr':'sum','reach':'sum','rtime':'mean','rv3':'sum',
         'rv25':'sum','rv75':'sum','rv100':'sum','thruplays':'sum','puja':'mean',
-        'url_final':lambda x: aggregate_strings(x, separator=' | ', max_len=None)
+        'url_final':lambda x: aggregate_strings(x, separator=' | ', max_len=None),
+        'Públicos In': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
+        'Públicos Ex': lambda x: aggregate_strings(x, separator=' | ', max_len=None)
     }
     agg_dict_available={k:v for k,v in agg_dict.items() if k in df_daily_agg_copy.columns} 
     if not agg_dict_available or 'spend' not in agg_dict_available or 'impr' not in agg_dict_available: 
@@ -936,8 +938,7 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
     if ads_global.empty: log_func("   No hay Ads con impresiones y gasto positivos."); return
 
     sort_cols_top=[]; ascend_top=[]
-    if 'spend' in ads_global: sort_cols_top.append('spend'); ascend_top.append(False) 
-    if 'roas' in ads_global: sort_cols_top.append('roas'); ascend_top.append(False)  
+    if 'roas' in ads_global: sort_cols_top.append('roas'); ascend_top.append(False)
 
     df_top=ads_global.copy()
     if sort_cols_top: 
@@ -951,7 +952,7 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         df_top=df_top.head(top_n)
 
     table_headers=[
-        'Campaña','AdSet','Anuncio','URL FINAL','Puja','ThruPlays',
+        'Campaña','AdSet','Anuncio','Públicos Incluidos','Públicos Excluidos','URL FINAL','Puja','ThruPlays',
         'Reproducciones 25%','Reproducciones 75%','Reproducciones 100%',
         'Tiempo RV (s)','Días Act','Gasto','ROAS','Compras','CVR (%)','AOV','NCPA','CTR (%)','Frecuencia'
     ]
@@ -963,6 +964,8 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         'Campaña':row_val.get('Campaign','-'),
         'AdSet':row_val.get('AdSet','-'),
         'Anuncio':row_val.get('Anuncio','-'),
+        'Públicos Incluidos': _clean_audience_string(row_val.get('Públicos In', '-')),
+        'Públicos Excluidos': _clean_audience_string(row_val.get('Públicos Ex', '-')),
         'URL FINAL':row_val.get('url_final','-'),
         'Puja':f"{detected_currency}{fmt_float(row_val.get('puja'),2)}" if pd.notna(row_val.get('puja')) else '-',
         'ThruPlays':fmt_int(row_val.get('thruplays')),
@@ -983,13 +986,13 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
     if table_data: 
         df_display=pd.DataFrame(table_data)
         df_display = df_display[[h for h in table_headers if h in df_display.columns]] 
-        num_cols=[h for h in df_display.columns if h not in ['Campaña','AdSet','Anuncio','URL FINAL']]
+        num_cols=[h for h in df_display.columns if h not in ['Campaña','AdSet','Anuncio','URL FINAL','Públicos Incluidos','Públicos Excluidos']]
         _format_dataframe_to_markdown(df_display,f"** Top {top_n} Ads por Gasto > ROAS (Global Acumulado) **",log_func,currency_cols=detected_currency, stability_cols=[], numeric_cols_for_alignment=num_cols)
     else: log_func(f"   No hay datos para mostrar en Top {top_n} Ads.");
-    log_func("\n  **Detalle Top Ads Histórico:** Muestra los anuncios con mejor rendimiento histórico, ordenados primero por mayor gasto total y luego por ROAS más alto. Todas las métricas son acumuladas globales.");
+    log_func("\n  **Detalle Top Ads Histórico:** Muestra los anuncios con mejor rendimiento histórico, ordenados por ROAS de mayor a menor. Todas las métricas son acumuladas globales.");
     log_func("  ---")
 
-def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_days_total_ad_df, log_func, detected_currency, top_n=15):
+def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_days_total_ad_df, log_func, detected_currency, top_n=20):
     """Genera tablas por semana con los Top Ads ordenados por ROAS e impresiones."""
     group_cols = ['Campaign', 'AdSet', 'Anuncio']
     if df_daily_agg is None or df_daily_agg.empty or 'date' not in df_daily_agg.columns:
@@ -1110,15 +1113,17 @@ def _generar_tabla_bitacora_top_ads(df_daily_agg, bitacora_periods_list, active_
                 'Campaña': camp,
                 'AdSet': adset,
                 'Días Act': dias_act,
+                'Públicos Incluidos': _clean_audience_string(key_row.get('Públicos In', '-')),
+                'Públicos Excluidos': _clean_audience_string(key_row.get('Públicos Ex', '-')),
             }
             row.update(metrics)
             table_rows.append(row)
 
         if table_rows:
             df_display = pd.DataFrame(table_rows)
-            column_order = ['Anuncio','Campaña','AdSet','Días Act'] + metric_labels
+            column_order = ['Anuncio','Campaña','AdSet','Días Act','Públicos Incluidos','Públicos Excluidos'] + metric_labels
             df_display = df_display[[c for c in column_order if c in df_display.columns]]
-            num_cols = [c for c in df_display.columns if c not in ['Anuncio','Campaña','AdSet']]
+            num_cols = [c for c in df_display.columns if c not in ['Anuncio','Campaña','AdSet','Públicos Incluidos','Públicos Excluidos']]
             _format_dataframe_to_markdown(df_display, f"Top {top_n} Ads Bitácora - {label}", log_func, numeric_cols_for_alignment=num_cols)
             any_table = True
 


### PR DESCRIPTION
## Summary
- expand active-day calculation to detect status column and Spanish values
- include audience info in Top Ads tables and sort by ROAS
- extend Top Ads lists to top 20 entries

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b53df0f1c8332bb0fd4bff44c5729